### PR TITLE
Fix switch/case compilation

### DIFF
--- a/src/amxjit/compiler_impl.cpp
+++ b/src/amxjit/compiler_impl.cpp
@@ -1033,7 +1033,7 @@ CodeBuffer *CompilerImpl::Compile(AMXRef amx) {
         }
 
         // No match found - go for default case.
-        asm_.jmp(GetLabel(case_table.GetDefaultAddress()));
+        asm_.jmp(instr.operand() - reinterpret_cast<cell>(amx.code()));
         break;
       }
       case OP_CASETBL:


### PR DESCRIPTION
I'm not 100% sure, but these changes helps me to resolve jit compilation error on Linux (not sure about Windows):
```
Program received signal SIGSEGV, Segmentation fault.
0xb7c5c6b3 in amxjit::CaseTable::GetDefaultAddress (this=0xbfffea8c)
    at /media/sf_dev/samp-plugin-jit/src/amxjit/disasm.cpp:265
265	  return records_[0].second;
(gdb) bt
#0  0xb7c5c6b3 in amxjit::CaseTable::GetDefaultAddress (this=0xbfffea8c)
    at /media/sf_dev/samp-plugin-jit/src/amxjit/disasm.cpp:265
#1  0xb7c464ad in amxjit::CompilerImpl::Compile (this=0x9cf0fd8, amx=...)
    at /media/sf_dev/samp-plugin-jit/src/amxjit/compiler_impl.cpp:1036
#2  0xb7c37749 in amxjit::Compiler::Compile (this=0xbfffeb68, amx=...)
    at /media/sf_dev/samp-plugin-jit/src/amxjit/compiler.cpp:49
#3  0xb7c35c8a in (anonymous namespace)::Compile (amx=0x9cb3578)
    at /media/sf_dev/samp-plugin-jit/src/jithandler.cpp:101
#4  0xb7c35e53 in JITHandler::Exec (this=0x8203770, retval=0x0, index=797)
    at /media/sf_dev/samp-plugin-jit/src/jithandler.cpp:139
#5  0xb7c361d5 in amx_Exec_JIT (amx=0x9cb3578, retval=0x0, index=797)
    at /media/sf_dev/samp-plugin-jit/src/plugin.cpp:63
#6  0xb6565db0 in ?? () from plugins/streamer.so
#7  0xb7b7d172 in Scripts::Script::InitHandlersRegistration() () from plugins/pawnraknet.so
#8  0xb7b5d561 in Scripts::Load(tagAMX*, bool) () from plugins/pawnraknet.so
#9  0xb7b5d78b in Plugin::AmxLoad(tagAMX*) () from plugins/pawnraknet.so
#10 0x080d1c89 in ?? ()
#11 0x080a4f5f in ?? ()
#12 0x080ab922 in ?? ()
#13 0x080aa0fd in ?? ()
#14 0xb7c97af3 in __libc_start_main (main=0x80a9420, argc=1, argv=0xbffff0a4, init=0x8150650, 
    fini=0x8150640, rtld_fini=0xb7fed300 <_dl_fini>, stack_end=0xbffff09c) at libc-start.c:287
#15 0x0804b4e1 in ?? ()
```